### PR TITLE
no side ways slide on mobile + center align the speakers ul

### DIFF
--- a/app/styles/components/_organizers.scss
+++ b/app/styles/components/_organizers.scss
@@ -20,7 +20,15 @@
 
   @include respond-to("up to phablet") {
     height: 25%;
+    width: 90%;
+    right: 15%;
   }
+
+  @include respond-to("mobile") {
+    height: 20%;
+    right: 11%;
+  }
+
 }
 
 .organizer {
@@ -77,6 +85,10 @@
 
   .title {
     font-weight: 400;
+  }
+
+  p {
+    padding-bottom: 30px;
   }
 }
 

--- a/app/styles/components/_speakers.scss
+++ b/app/styles/components/_speakers.scss
@@ -45,6 +45,14 @@
     @include margin-vertical($speaker-vertical-spacing);
     left: 8%;
   }
+
+   @include respond-to("up to phablet") {
+    left: 5% !important;
+  }
+
+  @include respond-to("mobile") {
+    left: 5% !important;
+  }
 }
 
 .speaker {


### PR DESCRIPTION
this was checked on G3 , Nexus, Iphone 6  - all portrait only.